### PR TITLE
Update readme on Statusline call

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,7 +531,7 @@ with the following properties:
 ### Statusline indicator
 
 ```vim
-echo nvim_treesitter#statusline(90)  " 90 can be any length
+echo nvim_treesitter#statusline({"indicator_size": 90})  " 90 can be any length
 module->expression_statement->call->identifier
 ```
 


### PR DESCRIPTION
Minor fix to the README. The code to handle just a number input is currently commented out https://github.com/nvim-treesitter/nvim-treesitter/blob/36830c4ce838f4e7b19d95d6099af1311f618c26/lua/nvim-treesitter/statusline.lua#L16